### PR TITLE
Add String() to SUIT_Component_Identifier

### DIFF
--- a/internal/suit/manifest.go
+++ b/internal/suit/manifest.go
@@ -9,6 +9,11 @@ package suit
 import (
 	"bytes"
 	"crypto"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/veraison/go-cose"
@@ -208,7 +213,42 @@ type Common struct {
 	// TODO: $$SUIT_Common-extensions
 }
 
-type ComponentID [][]byte
+type ComponentID []ComponentIDBytes
+
+func (c *ComponentID) String() string {
+	var s []string
+	for i := range *c {
+		s = append(s, (*c)[i].String())
+	}
+	return fmt.Sprintf("[%s]", strings.Join(s, ", "))
+}
+
+type ComponentIDBytes []byte
+
+// String returns a human-readable representation of the ComponentIDBytes with CBOR Diagnostic Notation.
+func (c ComponentIDBytes) String() string {
+	// try to represent with UTF-8 string => 'foo-bar'
+	utf8EncodedString := string(c)
+	if utf8.ValidString(utf8EncodedString) && isPrintableUTF8(c) {
+		return fmt.Sprintf("'%s'", utf8EncodedString)
+	}
+	// otherwise, represent with hex string => h'1234abcd'
+	return fmt.Sprintf("h'%s'", hex.EncodeToString(c))
+}
+
+func isPrintableUTF8(b []byte) bool {
+	for len(b) > 0 {
+		r, size := utf8.DecodeRune(b)
+		if r == utf8.RuneError && size == 1 {
+			return false // invalid rune
+		}
+		if !unicode.IsPrint(r) {
+			return false // non-printable rune
+		}
+		b = b[size:]
+	}
+	return true
+}
 
 type Digest struct {
 	_           struct{}       `cbor:",toarray"`

--- a/internal/suit/manifest_test.go
+++ b/internal/suit/manifest_test.go
@@ -239,3 +239,18 @@ func TestSUITManifest_UnmarshalManifest(t *testing.T) {
 		0x49, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x2e, 0x74, 0x78, 0x74, // 'hello.txt'
 	}, encodedComponentID)
 }
+
+func TestSUITComponentID_String(t *testing.T) {
+	componentID := ComponentID{
+		{0x70, 0x72, 0x65, 0x66, 0x69, 0x78},                   // 'prefix'
+		{0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x2e, 0x74, 0x78, 0x74}, // 'hello.txt'
+	}
+	assert.Equal(t, "['prefix', 'hello.txt']", componentID.String())
+}
+
+func TestSUITComponentID_String_NonUTF8(t *testing.T) {
+	componentID := ComponentID{{
+		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // non-UTF8 bytes
+	}}
+	assert.Equal(t, "[h'000102030405060708']", componentID.String())
+}

--- a/internal/suit/report_test.go
+++ b/internal/suit/report_test.go
@@ -57,7 +57,7 @@ func TestSUITReport_UnmarshalOK(t *testing.T) {
 	assert.Equal(t, 1, len(report.ReportRecords))
 	require.NotNil(t, report.ReportRecords[0].SystemClaims)
 	assert.Equal(t, &SystemPropertyClaims{
-		SystemComponentID: [][]byte{{0x00}},
+		SystemComponentID: []ComponentIDBytes{{0x00}},
 		ImageSize:         34768,
 	}, report.ReportRecords[0].SystemClaims)
 


### PR DESCRIPTION
Resolves #19 
- `['foo.bar']` for printable `SUIT_Component_Idnetifier`
- `[h'00']` otherwise